### PR TITLE
use AB::MB for configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,7 +25,7 @@ filename = dev_Build.PL
 filename = _build
 filename = _share
 [Prereqs / ConfigureRequires]
-Alien::Base=0.023
+Alien::Base::ModuleBuild=0.023
 ExtUtils::CppGuess=0.11
 [Prereqs / TestRequires]
 ; authordep Test::Pod = 1.43


### PR DESCRIPTION
This will ensure that `Alien::Base::ModuleBuild` is specified as a configure requires instead of `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
